### PR TITLE
added repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "use-key-hook": "^1.3.0"
   },
   "homepage": "/react-image-annotate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WorkAroundOnline/react-image-annotate.git"
+  },
   "scripts": {
     "start": "react-scripts start",
     "prepublishOnly": "echo 'You must be in the dist directory to publish' && [ -f ./Annotator/index.js ]",


### PR DESCRIPTION
There's currently no way to get to the source of [this project from NPM](https://www.npmjs.com/package/react-image-annotate); this should make it easier.