### PR TITLE
Allow to hide any of the header buttons and update the Readme with the new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ All of the following properties can be defined on the Annotator...
 | `onExit`                 | `MainLayoutState => any`                         | Called when "Save" is called.                                                           |               |
 | `RegionEditLabel`        | `Node`                                           | React Node overriding the form to update the region (see [`RegionLabel`](https://github.com/waoai/react-image-annotate/blob/master/src/RegionLabel/index.js))                                                          |               |
 | `allowComments`          | `boolean`                                        | Show a textarea to add comments on each annotation.                                     | `false`       |
+| `hidePrev`               | `boolean`                                        | Hide `Previous Image` button from the header bar.                                       | `false`       |
+| `hideNext`               | `boolean`                                        | Hide `Next Image` button from the header bar.                                           | `false`       |
+| `hideClone`              | `boolean`                                        | Hide `Clone` button from the header bar.                                                | `false`       |
+| `hideSettings`           | `boolean`                                        | Hide `Settings` button from the header bar.                                             | `false`       |
+| `hideFullScreen`         | `boolean`                                        | Hide `FullScreen/Window` button from the header bar.                                    | `false`       |
+| `hideSave`               | `boolean`                                        | Hide `Save` button from the header bar.                                                 | `false`       |
 
 ## Developers
 

--- a/src/Annotator/index.js
+++ b/src/Annotator/index.js
@@ -1,27 +1,26 @@
 // @flow
 
-import React, { useReducer, useEffect } from "react"
-import type { Node } from "react"
-import MainLayout from "../MainLayout"
 import type {
-  ToolEnum,
-  Image,
-  Mode,
-  MainLayoutState,
   Action,
+  Image,
+  MainLayoutState,
+  Mode,
+  ToolEnum,
 } from "../MainLayout/types"
-import type { KeypointsDefinition } from "../ImageCanvas/region-tools"
-import SettingsProvider from "../SettingsProvider"
+import React, { useEffect, useReducer } from "react"
+import makeImmutable, { without } from "seamless-immutable"
 
+import type { KeypointsDefinition } from "../ImageCanvas/region-tools"
+import MainLayout from "../MainLayout"
+import type { Node } from "react"
+import SettingsProvider from "../SettingsProvider"
 import combineReducers from "./reducers/combine-reducers.js"
 import generalReducer from "./reducers/general-reducer.js"
-import imageReducer from "./reducers/image-reducer.js"
-import videoReducer from "./reducers/video-reducer.js"
-import historyHandler from "./reducers/history-handler.js"
-
-import useEventCallback from "use-event-callback"
-import makeImmutable, { without } from "seamless-immutable"
 import getFromLocalStorage from "../utils/get-from-local-storage"
+import historyHandler from "./reducers/history-handler.js"
+import imageReducer from "./reducers/image-reducer.js"
+import useEventCallback from "use-event-callback"
+import videoReducer from "./reducers/video-reducer.js"
 
 type Props = {
   taskDescription?: string,
@@ -52,6 +51,10 @@ type Props = {
   hideHeaderText?: boolean,
   hideNext?: boolean,
   hidePrev?: boolean,
+  hideClone?: boolean,
+  hideSettings?: boolean,
+  hideFullScreen?: boolean,
+  hideSave?: boolean
 }
 
 export const Annotator = ({
@@ -91,6 +94,10 @@ export const Annotator = ({
   hideHeaderText,
   hideNext,
   hidePrev,
+  hideClone,
+  hideSettings,
+  hideFullScreen,
+  hideSave,
   allowComments,
 }: Props) => {
   if (typeof selectedImage === "string") {
@@ -187,6 +194,10 @@ export const Annotator = ({
         hideHeaderText={hideHeaderText}
         hideNext={hideNext}
         hidePrev={hidePrev}
+        hideClone={hideClone}
+        hideSettings={hideSettings}
+        hideFullScreen={hideFullScreen}
+        hideSave={hideSave}
       />
     </SettingsProvider>
   )

--- a/src/MainLayout/index.js
+++ b/src/MainLayout/index.js
@@ -1,34 +1,54 @@
 // @flow
 
-import React, { useRef, useCallback } from "react"
-import type { Node } from "react"
-import { makeStyles, styled } from "@material-ui/core/styles"
-import ImageCanvas from "../ImageCanvas"
-import styles from "./styles"
-import type { MainLayoutState, Action } from "./types"
-import useKey from "use-key-hook"
-import classnames from "classnames"
-import { useSettings } from "../SettingsProvider"
-import SettingsDialog from "../SettingsDialog"
-// import Fullscreen from "../Fullscreen"
+import type { Action, MainLayoutState } from "./types"
 import { FullScreen, useFullScreenHandle } from "react-full-screen"
-import getActiveImage from "../Annotator/reducers/get-active-image"
-import useImpliedVideoRegions from "./use-implied-video-regions"
-import { useDispatchHotkeyHandlers } from "../ShortcutsManager"
-import { withHotKeys } from "react-hotkeys"
-import iconDictionary from "./icon-dictionary"
-import KeyframeTimeline from "../KeyframeTimeline"
-import Workspace from "react-material-workspace-layout/Workspace"
-import DebugBox from "../DebugSidebarBox"
-import TagsSidebarBox from "../TagsSidebarBox"
-import KeyframesSelector from "../KeyframesSelectorSidebarBox"
-import TaskDescription from "../TaskDescriptionSidebarBox"
-import RegionSelector from "../RegionSelectorSidebarBox"
-import ImageSelector from "../ImageSelectorSidebarBox"
-import HistorySidebarBox from "../HistorySidebarBox"
-import useEventCallback from "use-event-callback"
-import getHotkeyHelpText from "../utils/get-hotkey-help-text"
+import React, { useCallback, useRef } from "react"
+import { makeStyles, styled } from "@material-ui/core/styles"
+
 import ClassSelectionMenu from "../ClassSelectionMenu"
+import DebugBox from "../DebugSidebarBox"
+import HistorySidebarBox from "../HistorySidebarBox"
+import ImageCanvas from "../ImageCanvas"
+import ImageSelector from "../ImageSelectorSidebarBox"
+import KeyframeTimeline from "../KeyframeTimeline"
+import KeyframesSelector from "../KeyframesSelectorSidebarBox"
+import type { Node } from "react"
+import RegionSelector from "../RegionSelectorSidebarBox"
+import SettingsDialog from "../SettingsDialog"
+import TagsSidebarBox from "../TagsSidebarBox"
+import TaskDescription from "../TaskDescriptionSidebarBox"
+import Workspace from "react-material-workspace-layout/Workspace"
+import classnames from "classnames"
+import getActiveImage from "../Annotator/reducers/get-active-image"
+import getHotkeyHelpText from "../utils/get-hotkey-help-text"
+import iconDictionary from "./icon-dictionary"
+import styles from "./styles"
+import { useDispatchHotkeyHandlers } from "../ShortcutsManager"
+import useEventCallback from "use-event-callback"
+import useImpliedVideoRegions from "./use-implied-video-regions"
+import useKey from "use-key-hook"
+import { useSettings } from "../SettingsProvider"
+import { withHotKeys } from "react-hotkeys"
+
+// import Fullscreen from "../Fullscreen"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 const emptyArr = []
 const useStyles = makeStyles(styles)
@@ -70,6 +90,10 @@ export const MainLayout = ({
   hideHeaderText,
   hideNext = false,
   hidePrev = false,
+  hideClone = false,
+  hideSettings = false,
+  hideFullScreen = false,
+  hideSave = false
 }: Props) => {
   const classes = useStyles()
   const settings = useSettings()
@@ -256,10 +280,10 @@ export const MainLayout = ({
                 : !state.videoPlaying
                 ? { name: "Play" }
                 : { name: "Pause" },
-              !nextImageHasRegions && activeImage.regions && { name: "Clone" },
-              { name: "Settings" },
-              state.fullScreen ? { name: "Window" } : { name: "Fullscreen" },
-              { name: "Save" },
+              !hideClone && !nextImageHasRegions && activeImage.regions && { name: "Clone" },
+              !hideSettings && { name: "Settings" },
+              !hideFullScreen && (state.fullScreen ? { name: "Window" } : { name: "Fullscreen" }),
+              !hideSave && { name: "Save" },
             ].filter(Boolean)}
             onClickHeaderItem={onClickHeaderItem}
             onClickIconSidebarItem={onClickIconSidebarItem}

--- a/src/MainLayout/index.js
+++ b/src/MainLayout/index.js
@@ -32,24 +32,6 @@ import { withHotKeys } from "react-hotkeys"
 
 // import Fullscreen from "../Fullscreen"
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 const emptyArr = []
 const useStyles = makeStyles(styles)
 


### PR DESCRIPTION
I've seen some issues like #104 that requested a way to choose which buttons to show or hide from the header bar. I have found the same "problem" (lack of feature) with a project of mine. Checking the code, I've seen that there were already a `hidePrev` and `hideNext` buttons that were not well documented.

Therefore, I have added a hide option for the rest of the buttons: Clone, Settings, Save and FullScreen/Window. I have also added the information about the existence of these properties in the [Readme Props section](https://github.com/UniversalDataTool/react-image-annotate#props).

I've noticed now that there are a noticeable amount of changes with the imports. Still, it's just the IDE that auto-sorted it automatically without me noticing it.